### PR TITLE
Updated class used to open the dropdown menu

### DIFF
--- a/src/Typeahead.react.js
+++ b/src/Typeahead.react.js
@@ -162,7 +162,7 @@ const Typeahead = React.createClass({
 
     return (
       <div
-        className="bootstrap-typeahead open"
+        className="bootstrap-typeahead show"
         style={{position: 'relative'}}>
         {this._renderInput(filteredOptions)}
         {this._renderMenu(filteredOptions)}


### PR DESCRIPTION
Fixed bug - latest version of bootstrap has renamed the class from "open" to "show".